### PR TITLE
remove trailing ')' for "syntax error, unexpected ')' in php-raml2htm…

### DIFF
--- a/inc/ramlDataObject.php
+++ b/inc/ramlDataObject.php
@@ -90,7 +90,7 @@ class RAMLDataObject
 	
 	public function isArray()
 	{
-		if ((is_array($this->data) || is_object($this->data)) && count($this->data) > 0)) {
+		if ((is_array($this->data) || is_object($this->data)) && count($this->data) > 0) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
…l/inc/ramlDataObject.php on line 93"