### PR TITLE
Fixed overwriting of mapping key in includes.

### DIFF
--- a/inc/raml.php
+++ b/inc/raml.php
@@ -478,7 +478,7 @@ class RAML extends RAMLDataObject
 				$ext = strtolower(array_pop($ext_t));
 				
 				if (in_array($ext, array('yaml', 'raml'))) {
-					$array[$key] = spyc_load_file($this->includePath . $matches[1]);
+					$array[$key] = $this->handleIncludes(spyc_load_file($this->includePath . $matches[1]));
 				} else {
 					$array[$key] = file_get_contents($this->includePath . $matches[1]);
 				}

--- a/inc/raml.php
+++ b/inc/raml.php
@@ -478,9 +478,7 @@ class RAML extends RAMLDataObject
 				$ext = strtolower(array_pop($ext_t));
 				
 				if (in_array($ext, array('yaml', 'raml'))) {
-					$t = spyc_load_file($this->includePath . $matches[1]);
-					$array = array_merge($t, $array);
-					unset($array[$key]);
+					$array[$key] = spyc_load_file($this->includePath . $matches[1]);
 				} else {
 					$array[$key] = file_get_contents($this->includePath . $matches[1]);
 				}


### PR DESCRIPTION
To meet the specification at
https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/#resolving-includes
Examples: 

`resourceTypes: !include resourceTypes.raml`

would have skipped the key resourceTypes, and included the content of the included file.
if the file resourceTypes would start with resourceTypes:
the node would have been completely deleted.

Same is true with other cases of file inclusion.